### PR TITLE
TEC-1192 Build with Xcode 12

### DIFF
--- a/airtime/CMakeLists.txt
+++ b/airtime/CMakeLists.txt
@@ -33,7 +33,7 @@ if (IOS)
 endif()
 
 # Disable warnings introduced in Xcode 7.3
-add_compile_options(-Wno-logical-not-parentheses)
+add_compile_options(-Wno-logical-not-parentheses -Wno-implicit-fallthrough)
 
 add_subdirectory(.. ${CMAKE_CURRENT_BINARY_DIR}/boringssl)
 set(CMAKE_SYSTEM_PROCESSOR ${ORIG_CMAKE_SYSTEM_PROCESSOR})


### PR DESCRIPTION
Disable implicit fallthrough warning.
