### PR TITLE
CAR-2229 update xcode 14.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CLANG)
 
   if(CLANG)
     set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wnewline-eof -fcolor-diagnostics")
+    # airtime: start
+    set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wno-unused-but-set-variable")
+    # airtime: end
   else()
     # GCC (at least 4.8.4) has a bug where it'll find unreachable free() calls
     # and declare that the code is trying to free a stack pointer.


### PR DESCRIPTION
This change should be undone in BXB-4286 because the latest version of boringssl gets rid of the offending line.
