### PR TITLE
BXB-4418 xcode15 cxx flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CLANG)
   if(CLANG)
     set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wnewline-eof -fcolor-diagnostics")
     # airtime: start
-    set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wno-unused-but-set-variable")
+    set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wno-unused-but-set-variable -Wno-array-parameter")
     # airtime: end
   else()
     # GCC (at least 4.8.4) has a bug where it'll find unreachable free() calls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CLANG)
   if(CLANG)
     set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wnewline-eof -fcolor-diagnostics")
     # airtime: start
+    # Disable warnings to compile on macOS
     set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wno-unused-but-set-variable -Wno-array-parameter")
     # airtime: end
   else()


### PR DESCRIPTION
In file included from boringssl/crypto/fipsmodule/bcm.c:43:
boringssl/crypto/fipsmodule/bn/generic.c:597:51: error: argument 'a' of type 'const uint64_t[8]' (aka 'const unsigned long long[8]') with mismatched bound [-Werror,-Warray-parameter]
void bn_sqr_comba8(BN_ULONG r[16], const BN_ULONG a[8]) {
boringssl/crypto/fipsmodule/bn/internal.h:292:51: note: previously declared as 'const uint64_t[4]' (aka 'const unsigned long long[4]') here
void bn_sqr_comba8(BN_ULONG r[16], const BN_ULONG a[4]); 
1 error generated.